### PR TITLE
Fix register loading loop when passwords don't match

### DIFF
--- a/src/hooks/useRegister.js
+++ b/src/hooks/useRegister.js
@@ -13,6 +13,7 @@ function useRegister() {
 
     if (password !== passwordCheck) {
       setError('Passwords must match');
+      setLoading(false);
       return;
     }
 


### PR DESCRIPTION
## 📌 Description
This PR fixes a bug when the passwords don't match in 'Register' page which keeps the 'Create Account' button 'Loading' forever.

## 🔍 Related Issues
No related issues.

## ✨ Changes Made
- Add 'Loading' state change when passwords don't match, resetting the 'Create account' button

## ✅ Checklist
- [x] My code follows the project's coding standards and guidelines
- [x] I have tested the changes locally to ensure they work as expected
- [x] No new warnings or errors in the console
- [x] The UI and functionality are responsive across different screen sizes.