### PR TITLE
Fix recipe cover image not being shown

### DIFF
--- a/src/components/RecipeCard.jsx
+++ b/src/components/RecipeCard.jsx
@@ -10,8 +10,8 @@ function RecipeCard(props) {
       <li>
         <Link to={`/recipes/${recipe.recipeId}`}
               className={'flex flex-col min-h-52 bg-white border-1 border-stone-200 shadow-md shadow-stone-300 rounded-xl transition duration-500 sm:flex-row hover:scale-103'}>
-          <div
-            className={`bg-center bg-[url(${recipe.coverImg})] w-full h-40 rounded-t-lg bg-stone-300 sm:h-auto sm:max-w-3xs sm:rounded-l-lg sm:rounded-t-none`}></div>
+          <div style={{ backgroundImage: `url(${recipe.coverImg})` }}
+               className={`bg-center bg-no-repeat bg-cover w-full h-50 rounded-t-lg bg-stone-300 sm:h-auto sm:max-w-3xs sm:rounded-l-lg sm:rounded-t-none`}></div>
 
           <div className={'flex flex-col w-full justify-between gap-4 p-4'}>
             <div className={'flex flex-col justify-between items-start gap-2 sm:flex-row'}>


### PR DESCRIPTION
## 📌 Description
This PR fixes recipe card cover image not being shown. There's a placeholder image set as default when a recipe doesn't have a custom cover image and this placeholder image wasn't loading properly.

## 🔍 Related Issues
No related issues,

## ✨ Changes Made
- Remove Tailwind CSS background-image property from `RecipeCard`
- Add inline style to proper set the background-image on recipe cover image `div`

## ✅ Checklist
- [x] My code follows the project's coding standards and guidelines
- [x] I have tested the changes locally to ensure they work as expected
- [x] No new warnings or errors in the console
- [x] The UI and functionality are responsive across different screen sizes.

## 🚀 Additional Notes
When the recipe creation feature gets done, all the created recipes will have a cover image, if user don't want to upload a custom image at the time, a default placeholder image will be set.